### PR TITLE
Add troubleshooting section to PlanetScale guide

### DIFF
--- a/content/running-on-planetscale.md
+++ b/content/running-on-planetscale.md
@@ -30,4 +30,3 @@ You can try add a connection timeout query parameter on your `DATABASE_URL`:
 ```
 DATABASE_URL=mysql://username:password@host/umami-db?sslaccept=strict&connect_timeout=300
 ```
-

--- a/content/running-on-planetscale.md
+++ b/content/running-on-planetscale.md
@@ -16,3 +16,18 @@ HASH_SALT=any-random-string
 6. Create the tables by running the following command on the root of the project: `pscale shell umami-db main < sql/schema.mysql.sql`.
 7. You should now be able to build and start Umami (`npm run build` followed by `npm start`).
 6. Follow the **Getting started** guide starting from the [Login](/docs/login) step and be sure to change the default password.
+
+## Troubleshooting
+
+If are getting an error like the following example:
+
+```
+PrismaClientInitializationError: Can't reach database server at `host.aws-region.psdb.cloud`:`3306`
+```
+
+You can try add a connection timeout query parameter on your `DATABASE_URL`:
+
+```
+DATABASE_URL=mysql://username:password@host/umami-db?sslaccept=strict&connect_timeout=300
+```
+


### PR DESCRIPTION
Hey, everyone! Last weekend I had the chance to test umami. The experience of making the umami run was very smooth. I just had a little problem while configuring umami with PlanetScale. Even following all the steps in the [guide](https://umami.is/docs/running-on-planetscale), the umami application returned an internal error:

```
PrismaClientInitializationError: Can't reach database server at `host.aws-region.psdb.cloud`:`3306`
```

I had to spend some time looking for the error solution on the internet. As the solution to the error is simple, I decided to create a PR suggesting adding the solution to the error in a troubleshooting section. I hope you like the idea! Thank you all for this lib and the excellent documentation!