### PR TITLE
update caprover deployment documentation

### DIFF
--- a/content/running-on-caprover.md
+++ b/content/running-on-caprover.md
@@ -12,7 +12,7 @@ It's blazingly fast and very robust as it uses Docker, nginx, LetsEncrypt and Ne
 
 ## Setup
 
-Setup of [CapRover Umami](https://github.com/tschannik/caprover-umami) is fairly easy. Follow the steps below to set up a Umami on CapRover:
+Setup of CapRover Umami is fairly easy. Follow the steps below to set up a Umami on CapRover:
 
 ### 1. Visit your CapRover Dashboard
 
@@ -23,25 +23,62 @@ If you don't have an existing CapRover instance check out their docs at [CapRove
 ### 2. Create app from template
 
 Click on the "Apps" section of your CapRover instance.
-Now select "One-Click Apps/Databases" and search for Umami and select it.
+Now select "One-Click Apps/Databases" and search for Umami you will find 3 option (`umami_postgresql`|`umami_mysql`|`mysql_only`).
 
-### 3. Setup Umami
+`umami_postgresql` will create umami with postgresql database.
 
-After selecting Umami from the CapRover One-Click Apps you'll be prompted with a setup page where you can specify some env variables. Notice how most of them are already configured.
+`umami_mysql` will create umami with mysql database.
+
+and `umami_only` will create umami alone and you need run your database infrastructure on your own and provide the database credentials in the setup.
+
+### 3. Setup Umami with database
+
+After selecting `umami_postgresql` or `umami_mysql` from the CapRover One-Click Apps you'll be prompted with a setup page where you can specify some env variables. Notice how most of them are already configured.
 
 - `App Name` is the display name for your Umami instance in CapRover
-- `PostgreSQL Version` can be any PostgreSQL version available on [PostgreSQL - Docker Hub](https://hub.docker.com/_/postgres). The default value has successfully been tested to work with Umami.
-- `CapRover Umami Version` refers to the CapRover Umami package found on [caprover-umami Docker Hub](https://hub.docker.com/r/tschannik/caprover-umami/tags). CapRover Umami ensures the correct setup of Umami on CapRover by pulling a PostgreSQL build of Umami and some checks to prevent whiping your data on restart or updates. Please have a look at the supported versions.
-- `Potgress Database password` provides the used password for your PostgreSQL database. There will always be a default value ready for you.
-- Optional: `Arguments for 'PostgreSQL initdb'` you can also provide arguments for PostgreSQL initdb like for example `--data-checksums`
+- `PostgreSQL or MYSQL Version` can be any PostgreSQL OR MYSQL version available on [PostgreSQL - Docker Hub](https://hub.docker.com/_/postgres) or [MYSQL - Docker Hub](https://hub.docker.com/_/mysql). The default value has successfully been tested to work with Umami.
+- `CapRover Umami Version` refers to the CapRover Umami latest release found on [umami release page](https://github.com/mikecao/umami/releases). Caprover Umami will use the official docker image that been released for specific database that you chose. instead of using the version number like `v.1.33.x` you can use `latest` to build using the latest version of umami.
+- `Database password` provides the used password for your database. There will always be a default value ready for you.
+- Optional: `Arguments for 'PostgreSQL initdb'` you can also provide arguments for PostgreSQL initdb like for example `--data-checksums` this option only available in `umami_postgresql`
+
+Now just click on "Deploy" to start the setup of your CapRover Umami instance with Database service.
+Please do not leave the page until it's done.
+
+### 4. Setup Umami without database services
+
+in some scenarios you may need to manage your database service on your own or use a remote database service for your umami application for doing that you can use `umami_only` CapRover app.
+
+before setting up this application you need create a database service using MYSQL or PostgreSQL.
+
+after you settings your database click on `umami_only` in CapRover and fill the variables in the Setup :
+
+- `App Name` is the display name for your Umami instance in CapRover
+- `CapRover Umami Version` refers to the CapRover Umami latest release found on [umami release page](https://github.com/mikecao/umami/releases). Caprover Umami will use the official docker image that been released for specific database that you chose. instead of using the version number like `v.1.33.x` you can use `latest` to build using the latest version of umami.
+- `Database Type` set to `postgresql` or `mysql` according to your database service.
+- `Database Remote URL` your database service remote url that umami can use to connect to the database. if your database is in your CapRover network use `srv-captain--appName` 
+- `Databse User` your database user
+- `Database Table` the table that you created for your umami application
+- `Database Password` your database password
 
 Now just click on "Deploy" to start the setup of your CapRover Umami instance.
+
 Please do not leave the page until it's done.
 
 ### 4. Final checkouts
 
 You're now able to login to your Umami deployment at `app-name.your-sub-domain.your-domain.xx` as described in the [Login](/docs/login) section. Please immediately change your password on the profile page.
 
+### 5. Updating existing umami instance
+
+first make a backup from your database before doing the update.
+
+after you make a backup from your database for updating your existing umami instance just go to the CapRover panel and select your umami app.
+
+go to `Deployment` tab and scroll down to `Deploy via ImageName` and deploy the desired version from (umami Docker Registery)[https://github.com/mikecao/umami/pkgs/container/umami]
+
+NOTE: do not forget to select the right docker image according to your database. usually the mysql images prefixed with `mysql_` and postgresql images prefixed with `postgresql_`.
+
+
 ## Support
 
-Chat with the CapRover Umami developers on [Github](https://github.com/tschannik/caprover-umami) if you need help or want to request a new version. We try to regularly update them ourselves.
+create an issue on [Github](https://github.com/caprover/one-click-apps/issues) .

--- a/content/running-on-caprover.md
+++ b/content/running-on-caprover.md
@@ -23,7 +23,7 @@ If you don't have an existing CapRover instance check out their docs at [CapRove
 ### 2. Create app from template
 
 Click on the "Apps" section of your CapRover instance.
-Now select "One-Click Apps/Databases" and search for Umami you will find 3 option (`umami_postgresql`|`umami_mysql`|`mysql_only`).
+Now select "One-Click Apps/Databases" and search for Umami you will find 3 option (`umami_postgresql`|`umami_mysql`|`umami_only`).
 
 `umami_postgresql` will create umami with postgresql database.
 

--- a/content/running-on-caprover.md
+++ b/content/running-on-caprover.md
@@ -74,7 +74,7 @@ first make a backup from your database before doing the update.
 
 after you make a backup from your database for updating your existing umami instance just go to the CapRover panel and select your umami app.
 
-go to `Deployment` tab and scroll down to `Deploy via ImageName` and deploy the desired version from (umami Docker Registery)[https://github.com/mikecao/umami/pkgs/container/umami]
+go to `Deployment` tab and scroll down to `Deploy via ImageName` and deploy the desired version from [umami Docker Registery](https://github.com/mikecao/umami/pkgs/container/umami)
 
 NOTE: do not forget to select the right docker image according to your database. usually the mysql images prefixed with `mysql_` and postgresql images prefixed with `postgresql_`.
 


### PR DESCRIPTION
I've made some changes in the CapRover one-click apps for umami.
I've updated the Caprover apps according to the latest v1.33.2 release. 
and added 2 more options to easily deploy on CapRover:
an option to deploy umami with MySQL service
and another option to deploy umami without database service.

~~the changes are not accepted yet. so I made this PR Draft till https://github.com/caprover/one-click-apps/pull/674 is accepted.~~