### PR TITLE
Fix typo in railway link

### DIFF
--- a/content/hosting.md
+++ b/content/hosting.md
@@ -24,7 +24,7 @@ that the app could connect to. Here are a few app hosting providers that can hos
 - [Vercel](https://vercel.com/)
 - [Netlify](https://www.netlify.com/)
 - [Render](https://render.com/)
-- [Railway](https://railway.up/)
+- [Railway](https://railway.app/)
 
 For the deployment, the build command is `npm run build` and the publish directory is `.next`.
 


### PR DESCRIPTION
Stumbled upon this typo when reading the docs. It now links to the correct [railway.app](https://railway.app/) instead of [railway.up](https://railway.up/)