### PR TITLE
chore: improve docs titles

### DIFF
--- a/pages/docs/[id].js
+++ b/pages/docs/[id].js
@@ -1,10 +1,31 @@
 import React from 'react';
 import Menu from 'components/Menu';
 import { getAllPathIds, getHtmlContent, CONTENT_DIR } from 'lib/content';
+import Head from 'next/head';
 
 export default function DocsPage({ content }) {
+  const contentTitle = React.useMemo(() => {
+    const contentArray = content.contentHtml.split('\n');
+    const h1 = contentArray.find(line => line.includes('<h1>'));
+
+    if (h1) {
+      // this regex removes the HTML tags from the content title
+      // <h1>About</h1> will become -> About
+      // see https://regexr.com/6r9cc
+      return h1.replace(/<\/?[^>]+(>|$)/g, '');
+    }
+
+    return null;
+  }, [content.contentHtml]);
+
   return (
     <div className="container markdown">
+      {contentTitle ? (
+        <Head>
+          <title>{`umami - ${contentTitle}`}</title>
+        </Head>
+      ) : null}
+
       <div className="row">
         <div className="col-12 col-lg-3">
           <Menu />


### PR DESCRIPTION
This will now add more information about the current doc's page. If the order of the title should be different, let me know!

Before:

![image](https://user-images.githubusercontent.com/53900565/183020166-d92ba5ed-6b76-463d-bb80-ecbf34fbad5f.png)

After:

![image](https://user-images.githubusercontent.com/53900565/183020234-5e9339d4-705e-4669-8a63-2a5e305c63db.png)
