### PR TITLE
Update example domains in docs for consistency

### DIFF
--- a/content/tracker-configuration.mdx
+++ b/content/tracker-configuration.mdx
@@ -10,7 +10,7 @@ to another location.
 Usage:
 ```
 <script async defer
-  src="http://mywebsite/umami.js"
+  src="http://mywebsite.com/umami.js"
   data-website-id="94db1cb1-74f4-4a40-ad6c-962362670409"
   data-host-url="http://stats.mywebsite.com"
 ></script>
@@ -24,7 +24,7 @@ track events yourself using the [tracker functions](/docs/tracker-functions).
 Usage:
 ```
 <script async defer
-  src="http://mywebsite/umami.js"
+  src="http://mywebsite.com/umami.js"
   data-website-id="94db1cb1-74f4-4a40-ad6c-962362670409"
   data-auto-track="false"
 ></script>
@@ -38,7 +38,7 @@ You can configure Umami to respect the visitor's **Do Not Track** setting.
 Usage:
 ```
 <script async defer
-  src="http://mywebsite/umami.js"
+  src="http://mywebsite.com/umami.js"
   data-website-id="94db1cb1-74f4-4a40-ad6c-962362670409"
   data-do-not-track="true"
 ></script>
@@ -54,7 +54,7 @@ improve the performance of the tracking script.
 Usage:
 ```
 <script async defer
-  src="http://mywebsite/umami.js"
+  src="http://mywebsite.com/umami.js"
   data-website-id="94db1cb1-74f4-4a40-ad6c-962362670409"
   data-cache="true"
 ></script>
@@ -67,7 +67,7 @@ If you want the tracker to only run on specific domains, you can add them to you
 Usage:
 ```
 <script async defer
-  src="http://mywebsite/umami.js"
+  src="http://mywebsite.com/umami.js"
   data-website-id="94db1cb1-74f4-4a40-ad6c-962362670409"
   data-domains="mywebsite.com,mywebsite2.com"
 ></script>


### PR DESCRIPTION
This commit adds an .com domain extension to the example domains. `mywebsite.com` is used in other documentation pages as well.