### PR TITLE
Add instructions to run Umami on Forge

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -35,6 +35,7 @@ const menu = {
     ['Running on Qovery', '/docs/running-on-qovery'],
     ['Running on CapRover', '/docs/running-on-caprover'],
     ['Running on Koyeb', '/docs/running-on-koyeb'],
+    ['Running on Forge', '/docs/running-on-forge'],
   ],
 };
 

--- a/content/running-on-forge.mdx
+++ b/content/running-on-forge.mdx
@@ -1,0 +1,71 @@
+# Running on Forge
+
+[Forge](https://forge.laravel.com/) is a paid server management services, tailored to hosting Laravel apps on Server Providers like DigitalOcean,
+Linode, Vultr, Amazon, Hetzner and more.
+
+If you have a Forge Account and a connected server bucket, you can easily set up an umami installation.
+
+## Prerequisites
+
+1. Configure the (sub) domain you would like to have Umami available on. Usually, you do this by configuring you DNS config with an A-Record that points to your bucket IP-Address.
+
+## Setup
+
+1. Select your desired  Server in Forge.
+2. Go to **Sites** > **New Site**
+    - Enter the domain name
+    - Project Type: Static HTML
+    - Check **Create Database**, enter a Database Name
+    - Click **Add**
+3. To install the Repository, fork the [https://github.com/umami-software/umami](https://github.com/umami-software/umami) project to your GitHub account or install from the official repository.
+    - Enter the Repository path: `umami-software/umami`
+    - Uncheck **Install Composer Dependencies**
+    - Click **Install Repository**
+4. Update the deployment script and add:
+```
+yarn install
+yarn build
+```
+after the `git pull origin $FORGE_SITE_BRANCH` command.
+
+Remove these lines, since we don't have artisan or use php:
+    ```
+    ( flock -w 10 9 || exit 1
+        echo 'Restarting FPM...'; sudo -S service $FORGE_PHP_FPM reload ) 9>/tmp/fpmlock
+
+    if [ -f artisan ]; then
+        $FORGE_PHP artisan migrate --force
+    fi
+    ```
+5. In Forge, go to your Server page, click **Database** and add a user to the just created database.
+6. Create the database-connection string and add it to your `.env` file:
+```
+DATABASE_URL=mysql://user:password@localhost:3306/dbname
+```
+7. Perform the initial project setup, via SSH:
+```
+    yarn install
+    yarn update-db
+    yarn build
+```
+8. Go to your Umami-Site and click on **SSL** in the left menu and add an SSL-Certificate.
+9. Click **Edit files** > **Edit Nginx Configuration** and add:
+```
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+```
+before the favicon.
+This configuration will route the traffic to the node-server that Umami runs on.
+
+10. In Forge, go to your Server page, click **Daemons** and add **New Daemon** to keep the Umami Node-Server up and running.
+    - Command: `yarn start`
+    - Directory: `/home/forge/umami.yourdomain.tld`
+    - Click **Create**
+
+You should now be able to reach your Umami project.


### PR DESCRIPTION
This pull request adds documentation on how to set up Umami with Laravel Forge.

Preview of the page that this PR adds:
[https://website-git-fork-crslp-master-umami-software.vercel.app/docs/running-on-forge](https://website-git-fork-crslp-master-umami-software.vercel.app/docs/running-on-forge)