### PR TITLE
[#99] Highlight Pricing link in desktop mode from right

### DIFF
--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -37,6 +37,7 @@
   gap: 48px;
   flex: 1;
   font-weight: 600;
+  z-index: 3;
 }
 
 .header .buttons {
@@ -44,6 +45,7 @@
   flex-direction: row;
   align-items: flex-end;
   justify-content: flex-end;
+  z-index: 2;
 }
 
 .header .menu {


### PR DESCRIPTION
The header component contains, among other things, a list of menu items and a "button" portion that has the GitHub icon.

In Safari with sidebar open, the middle-right portion of the "Pricing" text would not highlight. This is because the "hitbox" that responds to the event, the anchor tag itself, is _underneath_ the "button" portion.

This is evident in Safari debugger from Elements > Layout, and selecting Flexbox > "Page overlay options" for both Header__links and Header_buttons entries.

By assigning z-indices so that the menu items are on top, Pricing link highlights as expected from any portion of its text.

Resolves issue #99.

(99)