### PR TITLE
docs: update Railway instructions

### DIFF
--- a/content/v2/running-on-railway.mdx
+++ b/content/v2/running-on-railway.mdx
@@ -36,7 +36,9 @@ This initial deploy will fail until you follow the rest of these steps.
 
 ### Database and Deploy
 
-- Close the settings sidebar and click **New**, click **Database** and select **Add PostgreSQL**
+- Close the settings sidebar and click **New**, click **Database** and select **Add PostgreSQL**.
+- On the dashboard, select your Umami service, go to the **Variables** tab and click **New Variable**.
+- Click **Add Reference** and select the `DATABASE_URL` variable from your Postgres database. Click **Add**.
 
 Adding the database should trigger a re-deploy, and clicking the app link should get you to the login page of your Umami instance.
 


### PR DESCRIPTION
This PR adds missing instructions, how to add the `DATABASE_URL` from the Postgres DB
as a reference variable to the Umami service.

Without it, the deployment fails.

Related: https://github.com/umami-software/umami/issues/1947