### PR TITLE
Fix incorrect link in docs

### DIFF
--- a/content/v2/tracker-functions.mdx
+++ b/content/v2/tracker-functions.mdx
@@ -3,7 +3,7 @@
 The Umami tracker exposes a function that you can call on your website if you want
 more control over your tracking. By default everything is automatically collected, but you can
 disable this using `data-auto-track="false"` and sending the data yourself.
-See [Tracker configuration](http://localhost:5000/docs/tracker-configuration).
+See [Tracker configuration](/docs/tracker-configuration).
 
 ## Functions
 ```


### PR DESCRIPTION
Fix incorrect link on the `Tracker functions` page.