### PR TITLE
add setup instructions for neon, update vercel postgres

### DIFF
--- a/components/menu.v2.json
+++ b/components/menu.v2.json
@@ -161,7 +161,7 @@
         "url": "/docs/running-on-vercel"
       },
       {
-        "label": "Running on Neon",
+        "label": "Running on Neon Postgres",
         "url": "/docs/running-on-neon"
       },
       {

--- a/components/menu.v2.json
+++ b/components/menu.v2.json
@@ -161,6 +161,10 @@
         "url": "/docs/running-on-vercel"
       },
       {
+        "label": "Running on Neon",
+        "url": "/docs/running-on-neon"
+      },
+      {
         "label": "Running on Netlify",
         "url": "/docs/running-on-netlify"
       },

--- a/content/v2/running-on-neon.mdx
+++ b/content/v2/running-on-neon.mdx
@@ -1,4 +1,4 @@
-# Running on Neon
+# Running on Neon Postgres
 
 [Neon](https://neon.tech/) is a fully-managed serverless Postgres service.
 

--- a/content/v2/running-on-neon.mdx
+++ b/content/v2/running-on-neon.mdx
@@ -1,17 +1,17 @@
 # Running on Neon
 
-[Neon](https://neon.tech/) is a fully-managed Postgres service.
+[Neon](https://neon.tech/) is a fully-managed serverless Postgres service.
 
 ## Setup
 
 1. Create a project on Neon with a given name in a region close to where you will be hosting your Umami project.
-2. Get the database connection string with pooled connection enabled. It should look something like this: `postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb`
+    * You can also create a Neon project with the Neon CLI: `npx neonctl projects create`. The connection string will be printed to the console.
+2. Get the database connection string with pooled connection enabled. It should look something like this: `postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb`.
+    * You can also get the connection string with Neon CLI: `npx neonctl connection-string --project-id <project-id> --pooled`.
 3. **Important:** add `?pgbouncer=true&connect_timeout=10` to the connection string you just copied.
 4. Add `DATABASE_URL` to your `.env` file:
-
-```
-DATABASE_URL=postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb?pgbouncer=true&connect_timeout=10
-```
-
+    ```
+    DATABASE_URL=postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb?pgbouncer=true&connect_timeout=10
+    ```
 5. You should now be able to check the database connection and update the schema (`yarn run build-db && yarn run update-db`). 
 6. Follow the **Getting started** guide starting from the [Login](/docs/login) step and be sure to change the default password.

--- a/content/v2/running-on-neon.mdx
+++ b/content/v2/running-on-neon.mdx
@@ -1,0 +1,17 @@
+# Running on Neon
+
+[Neon](https://neon.tech/) is a fully-managed Postgres service.
+
+## Setup
+
+1. Create a project on Neon with a given name in a region close to where you will be hosting your Umami project.
+2. Get the database connection string with pooled connection enabled. It should look something like this: `postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb`
+3. **Important:** add `?pgbouncer=true&connect_timeout=10` to the connection string you just copied.
+4. Add `DATABASE_URL` to your `.env` file:
+
+```
+DATABASE_URL=postgres://user:passwd@endpoint-pooler.region.aws.neon.build/neondb?pgbouncer=true&connect_timeout=10
+```
+
+5. You should now be able to check the database connection and update the schema (`yarn run build-db && yarn run update-db`). 
+6. Follow the **Getting started** guide starting from the [Login](/docs/login) step and be sure to change the default password.

--- a/content/v2/running-on-vercel.mdx
+++ b/content/v2/running-on-vercel.mdx
@@ -3,9 +3,9 @@
 [Vercel](https://vercel.com/) is the company behind the framework [Next.js](https://nextjs.org/) which is used by Umami.
 They also provide a free hosting service which is ideal for Next.js applications.
 
-In this setup, you should already have a database server running and accepting remote connections.
-If you don't already have a database, you can follow the [Running on DigitalOcean](/docs/running-on-digitalocean) guide
-or the [Running on PlanetScale](/docs/running-on-planetscale) guide to get a database up and running.
+If you don't already have a database, you can create a Vercel Postgres database integration. You can also
+follow the [Running on DigitalOcean](/docs/running-on-digitalocean) guide or the
+[Running on PlanetScale](/docs/running-on-planetscale) guide to get a database up and running.
 You can also check out the **Managed databases** section under [Hosting](/docs/hosting).
 
 ## Setup [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami&env=DATABASE_URL)
@@ -16,7 +16,9 @@ _Automate steps 1-5 using the button above_
 2. Create an account on [Vercel](https://vercel.com/). 
 3. From the dashboard page click **Import Project** then specify the URL to your fork of the project on GitHub.
 4. Add the required environment variables `DATABASE_URL` to your Vercel project. These values are defined in the
-**Configure umami** step from [Install](/docs/install).
+**Configure umami** step from [Install](/docs/install). You can also create a Vercel Postgres database at this point.
+  * You should use `POSTGRES_PRISMA_URL` for umami, which is in the form of `postgres://user:passwd@endpoint-pooler.postgres.vercel-storage.com/verceldb?pgbouncer=true&connect_timeout=10`.
+  * The environment variable used for the database URL can be changed in `db/postgresql/prisma.schema` file.
 5. Deploy and visit your application at `<deploy-id>.vercel.app`.
 6. Follow the **Getting started** guide starting from the [Login](/docs/login) step and be sure to change the default password.
 

--- a/content/v2/running-on-vercel.mdx
+++ b/content/v2/running-on-vercel.mdx
@@ -18,7 +18,7 @@ _Automate steps 1-5 using the button above_
 4. Add the required environment variables `DATABASE_URL` to your Vercel project. These values are defined in the
 **Configure umami** step from [Install](/docs/install). You can also create a Vercel Postgres database at this point.
   * You should use `POSTGRES_PRISMA_URL` for umami, which is in the form of `postgres://user:passwd@endpoint-pooler.postgres.vercel-storage.com/verceldb?pgbouncer=true&connect_timeout=10`.
-  * The environment variable used for the database URL can be changed in `db/postgresql/prisma.schema` file.
+  * The environment variable used for the database URL can be changed in the `db/postgresql/prisma.schema` file.
 5. Deploy and visit your application at `<deploy-id>.vercel.app`.
 6. Follow the **Getting started** guide starting from the [Login](/docs/login) step and be sure to change the default password.
 


### PR DESCRIPTION
This PR adds setup instructions for Neon and Vercel Postgres. Like other database vendors as Supabase, the special thing is to add `pgbouncer=true`.

Neon + Prisma now supports setting up db schema with pooled connection, and therefore Prisma directUrl does not need to be set. However, `prisma migrate` requires a `directUrl` config, which uses a non-pooled connection. But given our users should not be running `prisma migrate dev` by themselves, we should be safe here to only set the database URL.

close https://github.com/umami-software/umami/issues/2100