### PR TITLE
Add guide for running Umami on Fly.io

### DIFF
--- a/src/app/docs/menu.v2.json
+++ b/src/app/docs/menu.v2.json
@@ -203,6 +203,10 @@
       {
         "label": "Running on Forge",
         "url": "/docs/running-on-forge"
+      },
+      {
+        "label": "Running on Fly.io",
+        "url": "/docs/running-on-fly-io"
       }
     ]
   }

--- a/src/app/docs/v2/running-on-fly-io.mdx
+++ b/src/app/docs/v2/running-on-fly-io.mdx
@@ -1,0 +1,60 @@
+# Running on Fly.io
+
+[Fly.io](https://fly.io) turns containers into VMs that can be deployed in one or multiple regions. The `fly launch` process can automatically set up Postgres VM that in connection with your Umami app.
+
+## Setup using Umami's pre-built container
+
+For anyone wishing to deploy Umami on Fly now, here's a simple method using  [Umami's pre-built container for postgres](https://github.com/umami-software/umami/pkgs/container/umami/123905077?tag=postgresql-latest) instead of pulling the source and modifying the Dockerfile.
+
+If you don't already have `flyctl` installed, [install it](https://fly.io/docs/hands-on/install-flyctl/).
+
+1. In an new directory for your app, create `fly.toml`:
+
+```toml
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+[experimental]
+auto_rollback = true
+
+[build]
+image = "ghcr.io/umami-software/umami:postgresql-latest"
+
+[env]
+HOSTNAME = "0.0.0.0"
+
+[[services]]
+protocol = "tcp"
+internal_port = 3000
+processes = ["app"]
+
+[[services.ports]]
+port = 80
+handlers = ["http"]
+force_https = true
+
+[[services.ports]]
+port = 443
+handlers = ["tls", "http"]
+
+[services.concurrency]
+type = "connections"
+hard_limit = 25
+soft_limit = 20
+
+[[services.tcp_checks]]
+interval = "15s"
+timeout = "2s"
+grace_period = "1s"
+```
+
+2. `fly launch` and choose to create an app with the found `fly.toml` configuration.
+3. Go through the launch steps, and choose `y` on the step to create a connected Postgres app.
+4. Choose not to deploy the app yet.
+5. `fly secrets set HASH_SALT="<any-string-minus-angle-brackets>"`, using whatever string you want to salt the hash.
+6. `fly deploy` There will be errors, but let the deployment complete.
+7. `fly scale memory 512` (or higher, if needed. Umami seems to fail with less than 512 MB RAM)
+8. `fly deploy`
+9. Following the [Umami docs](https://umami.is/docs/login), log in with user: `admin` and password: `umami`
+
+Adjust instance locations, number of machines, auto-scaling, custom domains for your Umami app, and any other Fly.io options as per Fly [docs](https://fly.io/docs/)


### PR DESCRIPTION
This is a simple guide for getting Umami running on Fly.io via Umami's pre-built container for Postgres