### PR TITLE
Update api-client.mdx

### DIFF
--- a/src/app/(website)/docs/v2/api-client.mdx
+++ b/src/app/(website)/docs/v2/api-client.mdx
@@ -38,7 +38,9 @@ More details on accessing Umami Cloud can be found under [API key](/docs/api-key
 Import the configured api-client and query using the available class methods.
 
 ```js
-import { client } from '@umami/api-client';
+import { getClient } from '@umami/api-client';
+
+const client = getClient();
 
 const { ok, data, status, error } = await client.getWebsites();
 ```


### PR DESCRIPTION
since `client` does not exist you have to call `getClient` to get the client.

Otherwise the `client` should be available in the `api-client` repo

<img width="717" alt="Capture d’écran 2023-12-07 à 16 52 09" src="https://github.com/umami-software/website/assets/23030942/a2cbc22d-f46d-442e-86e0-58e4782be57f">

EDIT:
Related issue in `api-client` repo: https://github.com/umami-software/api-client/issues/8