### PR TITLE
Fix text overflowing on mobile for the about page

### DIFF
--- a/src/app/(website)/about/About.tsx
+++ b/src/app/(website)/about/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
       <PageHeader>
         <h1>Company</h1>
       </PageHeader>
-      <TextBlock style={{ width: 600, margin: 'auto' }}>
+      <TextBlock style={{ margin: 'auto' }}>
         <p>
           Umami was founded with the belief that users should be empowered by the software they use
           and should not have to give up fundamental rights like privacy and data ownership in

--- a/src/components/layout/TextBlock.module.css
+++ b/src/components/layout/TextBlock.module.css
@@ -30,6 +30,12 @@
   color: var(--base700);
   font-size: max(14px, min(2vw, 16px));
   font-weight: 400;
+
+  @media (max-width: 600px) {
+    width: 100%;
+    max-width: 100%;
+    overflow-wrap: break-word;
+  }
 }
 
 .text.xl p {
@@ -55,3 +61,5 @@
 .text strong {
   color: var(--base900);
 }
+
+


### PR DESCRIPTION
On the current website the About page text overflows horizontally on mobile. This constrains the text on smaller screens to not create the overflow. This has the added benefit of bringing the hamburger menu on mobile back into the view of the user.

Current website:
<img alt="current website" src="https://github.com/umami-software/website/assets/86988982/c1e3405f-f732-4d3a-a0d4-40b6c2ff2557" width="200" />

With this fix:
<img alt="website with this fix" src="https://github.com/umami-software/website/assets/86988982/f9efac0f-2c49-492d-a9eb-fd483a61ce94" width="200" />
