### PR TITLE
Fix broken link in documentation

### DIFF
--- a/src/app/(website)/docs/v2/api-client.mdx
+++ b/src/app/(website)/docs/v2/api-client.mdx
@@ -35,7 +35,7 @@ UMAMI_API_KEY
 UMAMI_API_CLIENT_ENDPOINT
 ```
 
-More details on accessing Umami Cloud can be found under [API key](/docs/api-key).
+More details on accessing Umami Cloud can be found under [API key](/docs/cloud/api-key).
 
 ### Usage
 


### PR DESCRIPTION
"API keys" link here is broken: https://umami.is/docs/api-client
Seems has moved from `https://umami.is/docs/api-key` to https://umami.is/docs/cloud/api-key