### PR TITLE
Update fly.io docs - HOSTNAME env no longer needed

### DIFF
--- a/src/content/docs/v2/running-on-fly-io.mdx
+++ b/src/content/docs/v2/running-on-fly-io.mdx
@@ -24,9 +24,6 @@ auto_rollback = true
 [build]
 image = "ghcr.io/umami-software/umami:postgresql-latest"
 
-[env]
-HOSTNAME = "0.0.0.0"
-
 [[services]]
 protocol = "tcp"
 internal_port = 3000


### PR DESCRIPTION
HOSTNAME env variable is no longer needed since Umami version 2.7.0