### PR TITLE
Add ranges in IGNORE_IP env variable

### DIFF
--- a/src/content/docs/v2/environment-variables.mdx
+++ b/src/content/docs/v2/environment-variables.mdx
@@ -68,9 +68,9 @@ Umami collects completely anonymous telemetry data in order help improve the app
 If you are running on an environment which requires you to bind to a specific hostname or port, such as Heroku, you can add
 these variables and start your app with `npm run start-env` instead of `npm start`.
 
-### IGNORE_IP = &lt;ip addresses&gt;
+### IGNORE_IP = &lt;ip addresses or ranges&gt;
 
-You can provide a comma-delimited list of IP address to exclude from data collection.
+You can provide a comma-delimited list of IP addresses and ranges to exclude from data collection.
 
 ### IGNORE_HOSTNAME = &lt;hostname&gt;
 


### PR DESCRIPTION
Ranges can be used in `IGNORE_IP`  environment variable.