### PR TITLE
Add `umami-ruby` to the Integrations page in the docs

### DIFF
--- a/src/content/docs/v2/integrations.mdx
+++ b/src/content/docs/v2/integrations.mdx
@@ -20,3 +20,4 @@ title: Integrations
 - [Umami API for Javascript](https://github.com/umami-software/api-client)
 - [Umami API for PHP Laravel](https://github.com/atm-code/laravel-umami)
 - [Umami API for Python](https://github.com/mikeckennedy/umami-python)
+- [Umami API for Ruby](https://github.com/rameerez/umami-ruby)


### PR DESCRIPTION
`umami-ruby` is a Ruby wrapper for the Umami analytics API