### PR TITLE
Update running-on-forge.mdx

### DIFF
--- a/src/content/docs/guides/running-on-forge.mdx
+++ b/src/content/docs/guides/running-on-forge.mdx
@@ -75,6 +75,7 @@ If you have a Forge Account and a connected server bucket, you can easily set up
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection 'upgrade';
      proxy_set_header Host $host;
+     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_cache_bypass $http_upgrade;
    }
    ```


### PR DESCRIPTION
Adjust the location block to forward the user IP to umami. This fixes IP Geolocation.