### PR TITLE
fix user endpoint path in docs summery

### DIFF
--- a/src/content/docs/api/users-api.mdx
+++ b/src/content/docs/api/users-api.mdx
@@ -10,7 +10,7 @@ Operations around User management.
 
 ```text
 POST /api/users
-GET /api/users
+GET /api/admin/users
 POST /api/users/:userId
 GET /api/users/:userId
 DELETE /api/users/:userId


### PR DESCRIPTION
it's correct in the [header for the endpoint](https://umami.is/docs/api/users-api#get-/api/admin/users), but summery path is not in sync