### PR TITLE
fix: broken DigitalOcean link in docs/guides

### DIFF
--- a/src/content/docs/guides/hosting.mdx
+++ b/src/content/docs/guides/hosting.mdx
@@ -11,7 +11,7 @@ and server that can run [Node.js](https://nodejs.org/) (18.17 or newer).
 In this setup you would have the database and web server running on the same machine. You can optionally run Umami behind
 a dedicated web server like [Nginx](https://www.nginx.com/) or [Apache](https://httpd.apache.org/) and proxy requests to Umami.
 
-You can view the [Running on DigitalOcean](/docs/running-on-digitalocean) guide to learn how to set up a server.
+You can view the [Running on DigitalOcean](/docs/guides/running-on-digitalocean) guide to learn how to set up a server.
 
 ## Separate database and web server
 


### PR DESCRIPTION
As the title says, rn the link behind the "Running on DigitalOcean" is not found. 