### PR TITLE
Fixed incorrectly build link

### DIFF
--- a/src/app/(website)/WebAnalytics.tsx
+++ b/src/app/(website)/WebAnalytics.tsx
@@ -49,7 +49,7 @@ export default function WebAnalytics() {
       </div>
       <Flexbox justifyContent="center" alignItems="center">
         <Button variant="secondary" asChild>
-          <Link href="/src/app/(website)/WebAnalytics">
+          <Link href="/features">
             <Text>Explore more features </Text>
             <Icon size="sm">
               <Icons.Arrow />


### PR DESCRIPTION
Saw the tweet (https://x.com/umami_software/status/1849965933357650228) and wanted to explode, but I came across on a link that isn't linking to the correct page