### PR TITLE
fix: invalid guide link

### DIFF
--- a/src/content/docs/v1/hosting.mdx
+++ b/src/content/docs/v1/hosting.mdx
@@ -11,7 +11,7 @@ and server that can run [Node.js](https://nodejs.org/) (10.13 or newer).
 In this setup you would have the database and web server running on the same machine. You can optionally run Umami behind
 a dedicated web server like [Nginx](https://www.nginx.com/) or [Apache](https://httpd.apache.org/) and proxy requests to Umami.
 
-You can view the [Running on DigitalOcean](/docs/running-on-digitalocean) guide to learn how to set up a server.
+You can view the [Running on DigitalOcean](/docs/guides/running-on-digitalocean) guide to learn how to set up a server.
 
 ## Separate database and web server
 


### PR DESCRIPTION
The _Running on DigitalOcean_ link was invalid on the Hosting Guides page.