### PR TITLE
fix: close mobile nav after clicking on link

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { createPortal } from 'react-dom';
+import { Button, Icon, Icons } from '@umami/react-zen';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { Button, Icon, Icons } from '@umami/react-zen';
+import { createPortal } from 'react-dom';
 import styles from './MobileMenu.module.css';
 
 interface Props {
@@ -23,7 +23,7 @@ export default function MobileMenu({ items = [], onClose }: Props) {
       </Button>
       <div className={styles.items}>
         {items.map(({ label, value }) => (
-          <Link key={value} href={value} className={styles.item}>
+          <Link key={value} href={value} className={styles.item} onClick={onClose} prefetch>
             {label}
           </Link>
         ))}


### PR DESCRIPTION
This PR closes the `MobileMenu` after clicking a link by triggering the onClose function. The onClick event fires immediately, closing the dialog. To reduce the perceived wait time after clicking a link and closing the menu, I added prefetching.
Fixes #194 