### PR TITLE
docs: minor update on the Guide for Running on Railway

### DIFF
--- a/src/content/docs/guides/running-on-railway.mdx
+++ b/src/content/docs/guides/running-on-railway.mdx
@@ -22,7 +22,7 @@ You can find the URL in your project dashboard which you can visit by running `r
 
 ## Running on Railway from a forked repository
 
-The previously described method is the quickest and easiest way to get Umami up and running on Railway. However, this creates a new repository with a single commit under your GitHub account. You may want to use a forked repository instead to be able to conveniently receive updates from (or contribute pull requests to) the Umami source repository via GitHub.
+The previously described method is the quickest and easiest way to get Umami up and running on Railway. However, you may want to use a forked repository instead to be able to conveniently receive updates from (or contribute pull requests to) the Umami source repository via GitHub.
 
 ### Set up Railway project
 


### PR DESCRIPTION
After following the instructions on the guide, turns out it no longer creates a new repository with a single commit. I assume this is because it directly pulls from Docker Hub instead.

So here is a minor update removing that line, so future users will not be afraid of simply clicking the "Deploy on Railway" button.