### PR TITLE
docs: update Cloudflare steps

### DIFF
--- a/src/content/docs/enable-cloudflare-headers.mdx
+++ b/src/content/docs/enable-cloudflare-headers.mdx
@@ -11,7 +11,7 @@ configure Cloudflare to send additional headers.
 
 1. Log in to the Cloudflare dashboard and select your account and website.
 
-2.  Go to Rules > Transform Rules.
+2.  Go to Rules > Settings.
 
 3.  Go to the Managed Transforms tab.
 


### PR DESCRIPTION
Changed the navigation path from "Rules > Transform Rules" to "Rules > Settings" in the Cloudflare dashboard instructions.

![{3B650B5E-0ED4-4CF4-83C3-A5AFF731BDCB}](https://github.com/user-attachments/assets/6c20945d-42b9-495f-bc72-c835a5ec5bac)
