### PR TITLE
chore: revamp community site snippets

### DIFF
--- a/src/app/(website)/community/CommunityPage.module.css
+++ b/src/app/(website)/community/CommunityPage.module.css
@@ -23,30 +23,30 @@
   height: 100%;
 }
 
-.item header {
+.item h2 {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 10px;
-  color: var(--base-color-8);
   font-size: 24px;
   font-weight: 700;
 }
 
-.item header svg {
+.item h2 svg {
   width: 24px;
   height: 24px;
-  fill: var(--base-color-8);
 }
 
 .item p {
-  color: var(--base-color-7);
+  flex-grow: 1;
   font-size: max(14px, min(2vw, 16px));
   font-weight: 400;
+  text-align: center;
+  text-wrap: balance;
 }
 
-.item a {
-  align-self: center;
+.item div {
+  width: 100%;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/app/(website)/community/CommunityPage.tsx
+++ b/src/app/(website)/community/CommunityPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Button } from '@umami/react-zen';
+import { Box, Heading, Button, Icon, Icons } from '@umami/react-zen';
 import PageHeader from '@/components/PageHeader';
 import { GITHUB_URL, DISCORD_URL, X_URL, LINKEDIN_URL } from '@/lib/constants';
 import { Github, Discord, X, Linkedin } from '@/components/icons';
@@ -11,25 +11,25 @@ const items = [
     description:
       'Check out the Umami source code, report issues, request features and join discussions.',
     url: GITHUB_URL,
-    icon: <Github />,
+    icon: <Github aria-hidden="true" />,
   },
   {
     name: 'Discord',
     description: "Chat directly with developers and other users in Umami's Discord channel.",
     url: DISCORD_URL,
-    icon: <Discord />,
+    icon: <Discord aria-hidden="true" />,
   },
   {
     name: 'Twitter',
     description: 'Follow us on Twitter for the latest news and updates.',
     url: X_URL,
-    icon: <X />,
+    icon: <X aria-hidden="true" />,
   },
   {
     name: 'LinkedIn',
     description: 'Learn about our company.',
     url: LINKEDIN_URL,
-    icon: <Linkedin />,
+    icon: <Linkedin aria-hidden="true" />,
   },
 ];
 
@@ -42,17 +42,28 @@ export default function CommunityPage() {
       />
       <div className={styles.items}>
         {items.map(({ name, description, url, icon }) => (
-          <div key={name} className={styles.item}>
-            <header>
-              {icon} {name}
-            </header>
-            <p>{description}</p>
-            <Button variant="secondary">
-              <a href={url} target="_blank" data-umami-event={`community-${name}`}>
-                Explore
-              </a>
-            </Button>
-          </div>
+          <Box as="article" key={name} className={styles.item}>
+            <Heading as="h2">
+              {name} {icon}
+            </Heading>
+            <Box as="p">
+              {description}
+            </Box>
+            <Box as="div">
+              <Button asChild>
+                <a href={url} target="_blank" data-umami-event={`community-${name}`}>
+                  Explore 
+                  <Icon>
+                    {
+                      // see https://github.com/react-icons/react-icons/issues/1029
+                      //@ts-ignore
+                      <Icons.Arrow/>
+                    }
+                  </Icon>
+                </a>
+              </Button>
+            </Box>
+          </Box>
         ))}
       </div>
     </section>


### PR DESCRIPTION
As a new Umami user, I've been going through the Umami docs and website a lot and I've noticed that [community sites](https://umami.is/community) snippets are visually quite dimmed down and hard to read, almost as turned off, with color contrast of `1.53` (on contrast scale `1-21`, `1` is invisible eg white-on-white, `21` being default/max contrast, black-on-white; according to accessibility standards, `4` is required minimum and `7+` recommended minimum). Additionally, there happened to be some invalid HTML.

I made some example changes in PR, if something should be useful from it:

- Cleaned up HTML, which should also as a side effect improve technical SEO. I've used `@umami/react-zen` similar to the shiso blog implementation; also style-wise.
- Fixed color contrasts up to `15` by removing the former light gray styling.
- I've kept the `target="_blank"` link setup as it is used sitewide on similar link types, otherwise I'd remove it as it is not recommended practice nowadays in terms of best practices (ie only for certain cases; also, links that open a new window/tab should be denoted as such in terms of a11y). I haven't found a `Link` react-zen component, so I've leaved the original anchor tag, which is otherwise fine.
- Lastly, I switched heading icon position to follow the arrow icon position below as the text content appeared to me zig zag otherwise.

Before:

![image](https://github.com/user-attachments/assets/56886025-86e8-472c-bcd3-603fc7c7eb20)

After:

![image](https://github.com/user-attachments/assets/3fd027b1-5ba5-40c7-8aad-cfe86344d694)
